### PR TITLE
Fixed android-studio string temporarily. Better fix coming soon.

### DIFF
--- a/ideainspect.groovy
+++ b/ideainspect.groovy
@@ -219,7 +219,7 @@ private File findIdeaExecutable(OptionAccessor cliOpts) {
   def platform = System.properties['os.name'], scriptPath
   def ideaHome = cliOpts.i ?: (System.getenv("IDEA_HOME") ?: "idea")
   def executable = "idea"
-  if(ideaHome.contains("Android")){
+  if(ideaHome.toLowerCase().contains("android")){
   	executable = "studio"
   }
 


### PR DESCRIPTION
I fixed the issue by removing case from the search space. I'm going to redo the search in the next few days to search for the startup files instead of pathing strings. This should resolve #9. Good luck @hwesley!