### PR TITLE
return non-zero exit value when inspection errors are found

### DIFF
--- a/ideainspect.groovy
+++ b/ideainspect.groovy
@@ -118,7 +118,8 @@ if (exitValue != 0) fail("IDEA process returned with an unexpected return code o
 //
 // --- Now lets look on the results
 //
-analyzeResult(resultPath, acceptedLeves, skipResults, skipIssueFilesRegex)
+exitValue = analyzeResult(resultPath, acceptedLeves, skipResults, skipIssueFilesRegex)
+if (exitValue != 0) fail("Results contained ")
 
 //
 //  --- Helper functions

--- a/ideainspect.groovy
+++ b/ideainspect.groovy
@@ -119,7 +119,7 @@ if (exitValue != 0) fail("IDEA process returned with an unexpected return code o
 // --- Now lets look on the results
 //
 exitValue = analyzeResult(resultPath, acceptedLeves, skipResults, skipIssueFilesRegex)
-if (exitValue != 0) fail("Results contained ")
+if (exitValue != 0) fail("Found inspection results.")
 
 //
 //  --- Helper functions


### PR DESCRIPTION
Would be great if the script returned a non-zero exit value when Inspection results are found. This way I can easily configure our Jenkins job to fail if anything is found.